### PR TITLE
chore: disable kiro-skill in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,7 +15,6 @@
     "codex-skill@claude-code-settings": true,
     "autonomous-skill@claude-code-settings": true,
     "nanobanana-skill@claude-code-settings": true,
-    "kiro-skill@claude-code-settings": true,
     "spec-kit-skill@claude-code-settings": true,
     "code-simplifier@claude-plugins-official": true,
     "rust-analyzer-lsp@claude-plugins-official": true,


### PR DESCRIPTION
## Summary

Disables the kiro-skill in Claude Code settings.

## Changes
- Removed kiro-skill from enabled skills list in .claude/settings.json

## Reason
Skill not currently in use for this project.