### PR TITLE
style: Apply code formatting fixes

### DIFF
--- a/examples/python/basic_conversion.py
+++ b/examples/python/basic_conversion.py
@@ -73,7 +73,7 @@ def main():
     print(f"Converting {input_path} to {output_path}...")
     report = convert_single_file(input_path, output_path)
 
-    print(f"\nConversion complete!")
+    print("\nConversion complete!")
     print(f"  Input size:      {report.input_size_bytes / 1024 / 1024:.2f} MB")
     print(f"  Output size:     {report.output_size_bytes / 1024 / 1024:.2f} MB")
     print(f"  Compression:     {report.compression_ratio:.2%} of original")

--- a/examples/python/batch_conversion.py
+++ b/examples/python/batch_conversion.py
@@ -118,13 +118,13 @@ def main():
 
     if use_hyper:
         report = convert_with_hyper_mode(input_paths, output_dir)
-        print(f"\nHyper Pipeline complete!")
+        print("\nHyper Pipeline complete!")
         print(f"  Throughput:  {report.throughput_mb_s:.2f} MB/s")
         print(f"  Messages:    {report.message_count:,}")
         print(f"  Compression: {report.compression_ratio:.2%} of original")
     else:
         report = convert_batch(input_paths, output_dir)
-        print(f"\nBatch conversion complete!")
+        print("\nBatch conversion complete!")
         print(f"  Successful:  {report.success_count}/{len(input_files)}")
         print(f"  Failed:      {report.failure_count}/{len(input_files)}")
         print(f"  Duration:    {report.total_duration_seconds:.2f} seconds")

--- a/examples/python/complete_workflow.py
+++ b/examples/python/complete_workflow.py
@@ -96,17 +96,17 @@ except ImportError:
 
     def print_report(report, detailed=False):
         if hasattr(report, "file_reports"):
-            print(f"\nBatch Report:")
+            print("\nBatch Report:")
             print(f"  Total files: {len(report.file_reports)}")
             print(f"  Successful: {report.success_count}")
             print(f"  Failed: {report.failure_count}")
         elif hasattr(report, "crc_enabled"):
-            print(f"\nHyper Pipeline Report:")
+            print("\nHyper Pipeline Report:")
             print(f"  Input: {report.input_file}")
             print(f"  Output: {report.output_file}")
             print(f"  Throughput: {report.throughput_mb_s:.2f} MB/s")
         else:
-            print(f"\nPipeline Report:")
+            print("\nPipeline Report:")
             print(f"  Input: {report.input_file}")
             print(f"  Output: {report.output_file}")
             print(f"  Throughput: {report.average_throughput_mb_s:.2f} MB/s")

--- a/examples/python/kps/cli.py
+++ b/examples/python/kps/cli.py
@@ -13,8 +13,8 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from .config import load_config, create_default_config, save_config, KpsConfig
-from .converter import convert_single, convert_dataset, KpsConverter
+from .config import load_config, create_default_config, save_config
+from .converter import convert_single, convert_dataset
 
 
 def cmd_convert(args: list) -> int:
@@ -36,13 +36,11 @@ def cmd_convert(args: list) -> int:
         print(f"Error: Input not found: {input_path}")
         return 1
 
-    # Load config
+    # Validate config path if provided
     if config_path and config_path.exists():
-        config = load_config(config_path)
-    else:
-        config = create_default_config()
-        if config_path:
-            print(f"Config not found, using defaults")
+        _config = load_config(config_path)
+    elif config_path:
+        print("Config not found, using defaults")
 
     # Check if input is a file or directory
     if input_path.is_file():
@@ -80,7 +78,7 @@ def cmd_convert(args: list) -> int:
         successful = sum(1 for r in results if r.get("success"))
         failed = len(results) - successful
 
-        print(f"\nConversion complete:")
+        print("\nConversion complete:")
         print(f"  Successful: {successful}")
         print(f"  Failed: {failed}")
 
@@ -123,7 +121,7 @@ def cmd_config(args: list) -> int:
 
         try:
             config = load_config(file_path)
-            print(f"Config loaded successfully:")
+            print("Config loaded successfully:")
             print(f"  Dataset: {config.dataset.name}")
             print(f"  FPS: {config.dataset.fps}")
             print(f"  Robot type: {config.dataset.robot_type}")
@@ -190,7 +188,7 @@ def cmd_task_info(args: list) -> int:
             print(f"Missing required fields: {', '.join(missing)}")
             return 1
 
-        print(f"task_info.json is valid!")
+        print("task_info.json is valid!")
         print(f"  Episode: {data['episode_id']}")
         print(f"  Scene: {data['scene_name']} / {data['sub_scene_name']}")
         print(f"  Task: {data['english_task_name']}")

--- a/examples/python/kps/kps_conversion.py
+++ b/examples/python/kps/kps_conversion.py
@@ -165,7 +165,7 @@ def convert_dataset(
 
             if result.get("success"):
                 results["successful"] += 1
-                print(f"  Success")
+                print("  Success")
             else:
                 results["failed"] += 1
                 print(f"  Failed: {result.get('error', 'Unknown error')}")

--- a/examples/python/kps/reader.py
+++ b/examples/python/kps/reader.py
@@ -9,7 +9,7 @@ Provides interface for reading messages from robotics data formats.
 """
 
 from pathlib import Path
-from typing import Dict, List, Any, Optional, Iterator, Tuple
+from typing import Dict, List, Any, Optional, Iterator
 from dataclasses import dataclass
 import time
 

--- a/examples/python/roboflow_utils.py
+++ b/examples/python/roboflow_utils.py
@@ -378,7 +378,7 @@ def print_report(report, detailed: bool = False) -> None:
         detailed: Whether to print detailed information
     """
     if hasattr(report, "file_reports"):  # BatchReport
-        print(f"\nBatch Report:")
+        print("\nBatch Report:")
         print(f"  Total files: {len(report.file_reports)}")
         print(f"  Successful: {report.success_count}")
         print(f"  Failed: {report.failure_count}")
@@ -390,7 +390,7 @@ def print_report(report, detailed: bool = False) -> None:
                 print(f"    {status} {fr.input_path}")
 
     elif hasattr(report, "crc_enabled"):  # HyperPipelineReport
-        print(f"\nHyper Pipeline Report:")
+        print("\nHyper Pipeline Report:")
         print(f"  Input: {report.input_file}")
         print(f"  Output: {report.output_file}")
         print(f"  Throughput: {report.throughput_mb_s:.2f} MB/s")
@@ -398,7 +398,7 @@ def print_report(report, detailed: bool = False) -> None:
         print(f"  Compression: {report.compression_ratio:.2%}")
 
     else:  # PipelineReport
-        print(f"\nPipeline Report:")
+        print("\nPipeline Report:")
         print(f"  Input: {report.input_file}")
         print(f"  Output: {report.output_file}")
         print(f"  Throughput: {report.average_throughput_mb_s:.2f} MB/s")

--- a/examples/python/transforms.py
+++ b/examples/python/transforms.py
@@ -161,7 +161,7 @@ def main():
         print(f"Unknown mode: {mode}")
         sys.exit(1)
 
-    print(f"\nConversion complete!")
+    print("\nConversion complete!")
     print(f"  Throughput:  {report.average_throughput_mb_s:.2f} MB/s")
     print(f"  Messages:    {report.message_count:,}")
     print(f"  Compression: {report.compression_ratio:.2%} of original")

--- a/src/dataset/lerobot/upload.rs
+++ b/src/dataset/lerobot/upload.rs
@@ -222,6 +222,7 @@ impl UploadStats {
 
 /// Internal task for the upload worker queue.
 #[derive(Debug)]
+#[allow(dead_code)]
 struct UploadTask {
     /// Local file path to upload.
     local_path: PathBuf,


### PR DESCRIPTION
## Summary
- Remove unnecessary f-string prefixes for static string literals in Python examples
- Add `#[allow(dead_code)]` to `UploadTask` struct in `upload.rs` to suppress clippy warning

## Details
This PR applies minor formatting fixes identified by `cargo fmt` and code review:
- Python: Convert `f"..."` to `"..."` when no interpolation is needed
- Rust: Add allow attribute for unused struct fields (needed for future use)