### PR TITLE
fix: address Greptile review comments on PR #60

### DIFF
--- a/crates/roboflow-distributed/src/heartbeat.rs
+++ b/crates/roboflow-distributed/src/heartbeat.rs
@@ -307,7 +307,17 @@ impl HeartbeatManager {
 
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(interval);
-            ticker.tick().await; // Skip first tick for immediate+interval pattern
+
+            // Send first heartbeat immediately, then tick to reset the interval
+            if let Err(e) = update_heartbeat_inner(&tikv, &pod_id).await {
+                metrics.inc_errors();
+                tracing::error!(
+                    pod_id = %pod_id,
+                    error = %e,
+                    "Failed to send initial heartbeat"
+                );
+            }
+            ticker.tick().await; // Reset interval after immediate heartbeat
 
             loop {
                 tokio::select! {

--- a/crates/roboflow-distributed/src/tikv/client.rs
+++ b/crates/roboflow-distributed/src/tikv/client.rs
@@ -1015,6 +1015,7 @@ impl TikvClient {
             "Attempting to reclaim job"
         );
 
+        #[cfg(feature = "distributed")]
         {
             let inner = self.inner.as_ref().ok_or_else(|| {
                 TikvError::ConnectionFailed("TiKV client not initialized".to_string())


### PR DESCRIPTION
Fixes Greptile review comments from PR #60:
1. Add #[cfg(feature = distributed)] to reclaim_job implementation
2. Call update_heartbeat_inner immediately on startup