### PR TITLE
fix: correct test_worker_metrics_tracking assertion

### DIFF
--- a/crates/roboflow-distributed/tests/tikv_integration_test.rs
+++ b/crates/roboflow-distributed/tests/tikv_integration_test.rs
@@ -959,18 +959,18 @@ mod tests {
         assert_eq!(snapshot.jobs_failed, 0);
         assert_eq!(snapshot.active_jobs, 0);
 
-        // Test increments
+        // Test increments - simulate 2 jobs claimed, 1 completed
         metrics.inc_jobs_claimed();
-        metrics.inc_jobs_claimed();
-
-        metrics.inc_active_jobs();
+        metrics.inc_active_jobs(); // Job 1 starts
         metrics.inc_jobs_completed();
-        metrics.inc_active_jobs();
+        metrics.dec_active_jobs(); // Job 1 completes
+
+        metrics.inc_jobs_claimed(); // Job 2 claimed
 
         let snapshot = metrics.snapshot();
         assert_eq!(snapshot.jobs_claimed, 2);
         assert_eq!(snapshot.jobs_completed, 1);
-        assert_eq!(snapshot.active_jobs, 1);
+        assert_eq!(snapshot.active_jobs, 0); // Job 1 started and finished, Job 2 not started
     }
 
     // =============================================================================


### PR DESCRIPTION
## Summary
Fix failing `test_worker_metrics_tracking` in coverage tests.

## Root Cause
The test had a logic bug - it called `inc_active_jobs()` twice but asserted `active_jobs == 1`. The `WorkerMetrics` struct has both increment and decrement methods for tracking active jobs.

## Fix
Changed to use the correct pattern:
- `inc_active_jobs()` when a job starts
- `dec_active_jobs()` when a job completes (along with `inc_jobs_completed()`)

## Test
- [x] cargo fmt --check
- [x] cargo clippy -- -D warnings
- [x] cargo test --features distributed
