### PR TITLE
docs: add PR title conventions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,24 @@ PR titles should follow the same Conventional Commits format as commit messages:
 
 PR titles are public-facing and should be clean, descriptive, and free of internal project management artifacts (phase numbers, sprint tags, etc.).
 
+## Branch Naming
+
+Use descriptive branch names with prefixes:
+
+| Prefix | Usage |
+|--------|-------|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation changes |
+| `refactor/` | Code restructuring |
+| `test/` | Test changes |
+
+**Examples:**
+- `feat/graceful-shutdown`
+- `fix/frame-alignment`
+- `docs/pr-conventions`
+- `refactor/storage-layer`
+
 ## Git Workflow
 
 1. Create feature branch from `main`
@@ -102,6 +120,58 @@ PR titles are public-facing and should be clean, descriptive, and free of intern
 3. Push to remote
 4. Create PR with clear description and test checklist
 5. Ensure CI passes (`make lint && cargo test`)
+
+## Rebasing
+
+If your branch falls behind `main`:
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+If conflicts occur:
+1. Resolve conflicts in the affected files
+2. `git add <resolved-files>`
+3. `git rebase --continue`
+
+After successful rebase, force push:
+```bash
+git push --force-with-lease
+```
+
+**Never use `git push --force`** - always use `--force-with-lease` to prevent overwriting others' work.
+
+## Recovering Unmerged Changes
+
+If your PR is merged but you have local commits that weren't included (e.g., documentation updates made after the PR was created):
+
+1. Switch to main and pull latest:
+   ```bash
+   git checkout main && git pull
+   ```
+
+2. Create a new branch for the orphaned changes:
+   ```bash
+   git checkout -b new-branch-name
+   ```
+
+3. Cherry-pick the specific commit:
+   ```bash
+   git cherry-pick <commit-hash>
+   ```
+
+4. Push and create a new PR.
+
+## Code Review
+
+Automated review tools (e.g., Greptile) may provide feedback on PRs. When addressing review comments:
+
+- Read the comment carefully to understand the specific issue
+- Make targeted fixes that address the exact concern
+- Verify tests pass after changes
+- Commit fixes with descriptive messages (e.g., `fix: address Greptile review comments`)
+- Push updates; the PR will automatically re-run checks
 
 ## Feature Flags
 


### PR DESCRIPTION
## Summary

Documents PR title conventions to follow open source best practices.

## Changes

- Adds "Pull Request Titles" section to CLAUDE.md
- Specifies that PR titles should follow Conventional Commits format
- Provides examples of good vs bad PR titles
- Explicitly prohibits internal project management tags (phase numbers, sprint tags)

## Motivation

During review of #80, the PR title needed refinement from  to follow standard open source conventions. Documenting this prevents future issues.